### PR TITLE
Removed the excess source.ruby scope from interpolation end brackets

### DIFF
--- a/syntaxes/ruby.tmLanguage
+++ b/syntaxes/ruby.tmLanguage
@@ -2662,11 +2662,6 @@
               <key>name</key>
               <string>punctuation.section.embedded.end.ruby</string>
             </dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>source.ruby</string>
-            </dict>
           </dict>
           <key>name</key>
           <string>meta.embedded.line.ruby</string>


### PR DESCRIPTION
Before:
![interpolation_before](https://user-images.githubusercontent.com/2983624/43683773-81e3f1da-989b-11e8-9fa3-a5a3f4a29ab5.png)

After:
![interpolation_after](https://user-images.githubusercontent.com/2983624/43683774-84e4eca4-989b-11e8-97bc-d11ae89bf7ce.png)
